### PR TITLE
Prevent magma creepers from filling the mob cap on biomes added in the Nether update

### DIFF
--- a/src/main/resources/data/elementalcreepers/forge/biome_modifier/magma_creeper_spawns.json
+++ b/src/main/resources/data/elementalcreepers/forge/biome_modifier/magma_creeper_spawns.json
@@ -1,6 +1,6 @@
 {
 	"type": "forge:add_spawns",
-	"biomes": "#minecraft:is_nether",
+	"biomes": "#elementalcreepers:can_spawn_magma_creeper",
 	"spawners":
 	{
 		"type": "elementalcreepers:magma_creeper",

--- a/src/main/resources/data/elementalcreepers/tags/worldgen/biome/can_spawn_magma_creeper.json
+++ b/src/main/resources/data/elementalcreepers/tags/worldgen/biome/can_spawn_magma_creeper.json
@@ -1,0 +1,5 @@
+{
+    "values": [
+        "minecraft:nether_wastes"
+    ]
+}


### PR DESCRIPTION
This pull requests aims to fix an issue with mob spawning in nether biomes by restricting magma creepers to only spawn on the nether wastes biome.

Before this patch, no enderman would spawn on the warped forest biome due to the magma creepers quickly filling mob cap.